### PR TITLE
dependabot.ymlのnpmに`groups.typescript-eslint` 追記

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,8 @@ updates:
       prefix: 'npm'
       include: 'scope'
     target-branch: 'main'
+    open-pull-requests-limit: 10
+    groups:
+      typescript-eslint:
+        patterns:
+          - '@typescript-eslint/*'


### PR DESCRIPTION
resolve #167