### PR TITLE
Deprecateされる`set-output`の代わりに`$GITHUB_OUTPUT`を使用

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Get version
         id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Upload files
         run: npx @google/clasp push --force


### PR DESCRIPTION
resolve #101 